### PR TITLE
fix: Starting blocks for new contract in Amoy

### DIFF
--- a/src/common/utils/config.ts
+++ b/src/common/utils/config.ts
@@ -51,7 +51,7 @@ export const processorConfigV2: Record<Network, Partial<Record<ChainId, Processo
     },
     [ChainId.MATIC_AMOY]: {
       marketplaceAddress: '0x1b67d0e31eeb6b52d8eeed71d3616c2f5b33b8e7',
-      fromBlock: 27973528,
+      fromBlock: 27973529,
       gatewayNetwork: 'polygon-amoy-testnet'
     }
   }

--- a/src/common/utils/config.ts
+++ b/src/common/utils/config.ts
@@ -51,7 +51,7 @@ export const processorConfigV2: Record<Network, Partial<Record<ChainId, Processo
     },
     [ChainId.MATIC_AMOY]: {
       marketplaceAddress: '0x1b67d0e31eeb6b52d8eeed71d3616c2f5b33b8e7',
-      fromBlock: 77807803,
+      fromBlock: 27973528,
       gatewayNetwork: 'polygon-amoy-testnet'
     }
   }


### PR DESCRIPTION
The starting block should be 27973529, taking into consideration the block [when the contract was created](https://amoy.polygonscan.com/address/0x1b67d0e31eeb6b52d8eeed71d3616c2f5b33b8e7)