### PR TITLE
chore: upgrade evm-processor and add gateway api key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-sns": "^3.622.0",
         "@dcl/schemas": "^13.4.0",
         "@subsquid/evm-abi": "^0.3.0",
-        "@subsquid/evm-processor": "^1.19.1",
+        "@subsquid/evm-processor": "^1.30.1",
         "@subsquid/typeorm-migration": "^1.3.0",
         "@subsquid/typeorm-store": "^1.5.1",
         "dotenv": "^16.4.5",
@@ -2382,20 +2382,21 @@
       }
     },
     "node_modules/@subsquid/evm-processor": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/evm-processor/-/evm-processor-1.19.1.tgz",
-      "integrity": "sha512-wJIzd5bMDDZmOZ0cgjzobqdFt+UtBRwEb4jtpb47Z4uZuPketrKSxG3njcs3V6DaqbdwAXiHBmWhbo7TMkHjPQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/evm-processor/-/evm-processor-1.30.1.tgz",
+      "integrity": "sha512-7wOZaaw2lBVfSnhiDBDwUTf93jv7G6A6AdmqV4OWs9GWXLcQAdmL8PgcCFTKguMFvxgXsSx5y+uWs7llWDecLA==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/http-client": "^1.4.0",
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/rpc-client": "^4.9.0",
-        "@subsquid/util-internal": "^3.2.0",
-        "@subsquid/util-internal-archive-client": "^0.1.2",
-        "@subsquid/util-internal-hex": "^1.2.2",
-        "@subsquid/util-internal-ingest-tools": "^1.1.2",
-        "@subsquid/util-internal-processor-tools": "^4.1.1",
+        "@subsquid/http-client": "^1.8.1",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/rpc-client": "^4.15.0",
+        "@subsquid/util-internal": "^3.3.0",
+        "@subsquid/util-internal-archive-client": "^0.2.1",
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-ingest-tools": "^1.1.5",
+        "@subsquid/util-internal-processor-tools": "^4.4.0",
         "@subsquid/util-internal-range": "^0.3.0",
-        "@subsquid/util-internal-validation": "^0.5.0",
+        "@subsquid/util-internal-validation": "^0.9.0",
         "@subsquid/util-timeout": "^2.3.2"
       }
     },
@@ -2425,22 +2426,24 @@
       "dev": true
     },
     "node_modules/@subsquid/http-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.4.0.tgz",
-      "integrity": "sha512-y+exFBQygbdvhmMrXVMUMkSQnmW8w7jz7zbRSCvjJRfmzXLjIi9dOQT2eIGN7e9GY/MvsW/qpDJEWhIbkcHsuw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.8.1.tgz",
+      "integrity": "sha512-JDOqZ2DxhOfmZaoeo0+l3MOseTbbhVAz+3VkNBAhfOdenHTKHTYrywjC1AbqtzFZCswW7ErSFsEsIk+y5GsbGQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.1.0",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
         "node-fetch": "^3.3.2"
       }
     },
     "node_modules/@subsquid/logger": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.3.tgz",
-      "integrity": "sha512-BdoRVIOrIRzKdMZPoJxzJzPLulf5Q09GeLtJn0whP+rhDV5nQ4ANDAzjPg9jmgH9WkMYAr2XH4lny/4PjhQUNA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.2",
-        "@subsquid/util-internal-json": "^1.2.2",
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-json": "^1.2.3",
         "supports-color": "^8.1.1"
       }
     },
@@ -2482,13 +2485,14 @@
       }
     },
     "node_modules/@subsquid/rpc-client": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.9.0.tgz",
-      "integrity": "sha512-lpb6qRMMlaacXOFPRhv4CZ7g4w7pKIR7ZEbMjyFexLOdv9MkcYzuGD5XT5REGaBA6mfQMaLa33K5lqAb+tJKBQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.15.0.tgz",
+      "integrity": "sha512-RwE0TNvX6fyUKk5DB4xXKlZgTLeENkYEHWeCIJH4GJylO4Os2GXYaytzr3NeZc8of7E49qz/HMFSxQvw//Hxyw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/http-client": "^1.4.0",
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/http-client": "^1.8.1",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0",
         "@subsquid/util-internal-counters": "^1.3.2",
         "@subsquid/util-internal-json-fix-unsafe-integers": "^0.0.0",
@@ -2566,21 +2570,23 @@
       }
     },
     "node_modules/@subsquid/util-internal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.2.0.tgz",
-      "integrity": "sha512-foNCjOmZaP8MKMa9sNe2GXTjFSDM9UqA0I0C0/ZvCxM1lCmG3mxZb70f8Wyi7TePXC/eV8eARbIqFyz0GjQmzA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.3.0.tgz",
+      "integrity": "sha512-WmMPHnqJcVIjM7BRNSd5uGYHVqlakr4fbyUIM2vQmfVx8V2ks+EWoreV0vsnSIyvDEqnoGJl8945xVhYkGkE3A==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-archive-client": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.1.2.tgz",
-      "integrity": "sha512-XATZWOIHUqIuqzb9hxaFIsz/BItb5qLoYjk6uhFcR9ART2AExXLU5l26SvSrq3hUnqfznIkQMZVQ1SKqnGzx4g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.2.1.tgz",
+      "integrity": "sha512-jGO3revw8fPSnbEDOZ1ciyZ6sbk9oPbieC8O0n9LipF5Bpc7BBIN6SyTfG9r3bXL86AzN4iMtCKuLtUbkvaFlw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/util-internal": "^3.1.0",
+        "@subsquid/util-internal": "^3.2.0",
         "@subsquid/util-internal-range": "^0.3.0"
       },
       "peerDependencies": {
-        "@subsquid/http-client": "^1.4.0",
-        "@subsquid/logger": "^1.3.3"
+        "@subsquid/http-client": "^1.8.0",
+        "@subsquid/logger": "^1.5.0"
       },
       "peerDependenciesMeta": {
         "@subsquid/logger": {
@@ -2591,7 +2597,8 @@
     "node_modules/@subsquid/util-internal-binary-heap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-binary-heap/-/util-internal-binary-heap-1.0.0.tgz",
-      "integrity": "sha512-88auuc8yNFmCZugmJSTYzS7WM/nN2obKGQCgrl8Jty5rJUFbqazGSi8icqftKhv6MPtUMJ3PSTRLiTFXAUGnAA=="
+      "integrity": "sha512-88auuc8yNFmCZugmJSTYzS7WM/nN2obKGQCgrl8Jty5rJUFbqazGSi8icqftKhv6MPtUMJ3PSTRLiTFXAUGnAA==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-code-printer": {
       "version": "1.2.2",
@@ -2610,12 +2617,14 @@
     "node_modules/@subsquid/util-internal-counters": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-counters/-/util-internal-counters-1.3.2.tgz",
-      "integrity": "sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng=="
+      "integrity": "sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-hex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.2.tgz",
-      "integrity": "sha512-E43HVqf23jP5hvtWF9GsiN8luANjnJ1daR2SVTwaIUAYU/uNjv1Bi6tHz2uexlflBhyxAgBDmHgunXZ45wQTIw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.3.tgz",
+      "integrity": "sha512-rGIQKHP+RpriJR56oL/AD43H/KX1EQwsvUy8nP6IHnk/vmaLyC2ECTp5n0jB7kq4NYK4C2VotP3lXHR0vWpa0A==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-http-server": {
       "version": "2.0.0",
@@ -2627,16 +2636,17 @@
       }
     },
     "node_modules/@subsquid/util-internal-ingest-tools": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-1.1.4.tgz",
-      "integrity": "sha512-2xWyqfg0mITsNdsYuGi3++UTy/D04N69KovyW5Rd71zCDSEedV0ePX5hQl/IT/o+H/u++HcXPggwJMVl09g6kQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-1.2.0.tgz",
+      "integrity": "sha512-Uufe/pvJ0fBm6UAQetuxGtvZqc1CcwlOtNRiDgZTXiYfyjT2BeykLLiuTQaQ5Pv8iVLRxqfJngge7A63eGvhnQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
         "@subsquid/util-internal-range": "^0.3.0"
       },
       "peerDependencies": {
-        "@subsquid/util-internal-archive-client": "^0.1.2"
+        "@subsquid/util-internal-archive-client": "^0.2.1"
       },
       "peerDependenciesMeta": {
         "@subsquid/util-internal-archive-client": {
@@ -2655,14 +2665,16 @@
     "node_modules/@subsquid/util-internal-json-fix-unsafe-integers": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json-fix-unsafe-integers/-/util-internal-json-fix-unsafe-integers-0.0.0.tgz",
-      "integrity": "sha512-mtbN15IgXtV4yo98RQla+O3DhFwB28o3JTBrFuBc/i/qzxyZNbKoVdq/uczomGdXrHxGkWhTDe/istIQe9gn6w=="
+      "integrity": "sha512-mtbN15IgXtV4yo98RQla+O3DhFwB28o3JTBrFuBc/i/qzxyZNbKoVdq/uczomGdXrHxGkWhTDe/istIQe9gn6w==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-processor-tools": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.1.1.tgz",
-      "integrity": "sha512-zzisejusRteAvwjqFDLlFapH9b86E8GdfNswuNWSjASE+VWadJ/PLfrlXFnsbAo4SxPKtqXWEewoK8cjzVjaZA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.4.0.tgz",
+      "integrity": "sha512-Ov2gFOcaGr7qVhYoqx+EIUjskGLRJRImQaEal5e0uNjX1sLG1bKfz+rXh1YMYCIUFwKd86fAGyLjVWwvnG0V8w==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/logger": "^1.3.3",
+        "@subsquid/logger": "^1.5.0",
         "@subsquid/util-internal": "^3.2.0",
         "@subsquid/util-internal-counters": "^1.3.2",
         "@subsquid/util-internal-prometheus-server": "^1.3.0",
@@ -2675,6 +2687,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-prometheus-server/-/util-internal-prometheus-server-1.3.0.tgz",
       "integrity": "sha512-E/ch5mxBg1CIGPsuAqUAQ7vVln2oTPm+Rl+0WYweH8JeZ81rD01XAmxhDuZzZnMMMzfZd9W4NlE4mCXbhSY1Ug==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@subsquid/util-internal-http-server": "^2.0.0"
       },
@@ -2686,6 +2699,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-range/-/util-internal-range-0.3.0.tgz",
       "integrity": "sha512-5/oDNW0TS66o4vWRzYSYXEfNnFRZsAzoi4pZNdPn7n1l+xV7ZTa0Y57XA6cP5hrWCaIYav4z1zECPngLDV/qeQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@subsquid/util-internal": "^3.1.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0"
@@ -2694,7 +2708,8 @@
     "node_modules/@subsquid/util-internal-squid-id": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-squid-id/-/util-internal-squid-id-0.0.0.tgz",
-      "integrity": "sha512-LyVZIGUbC87r+3VFBRiNOEycxvpkOEEjt5enY02iGl6MneLwq3m17D44xAkwfFj/U+t7GA76eeHIoI2ZkiQKog=="
+      "integrity": "sha512-LyVZIGUbC87r+3VFBRiNOEycxvpkOEEjt5enY02iGl6MneLwq3m17D44xAkwfFj/U+t7GA76eeHIoI2ZkiQKog==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-ts-node": {
       "version": "0.0.0",
@@ -2702,11 +2717,12 @@
       "integrity": "sha512-VBnrKrkNcqbT3hMLrjpEPuwMAihFhW9oUmK53bccBCCXrUiATNUblQD2S4IWd9/UBO5Q33ohpbE9sAodDq2DXw=="
     },
     "node_modules/@subsquid/util-internal-validation": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.5.0.tgz",
-      "integrity": "sha512-mGiwOzc/Fq651CbFe7aEpERXBr+BkqAz8cDpqTVAsve6ghvB5tvwlAv7i1MWnyt/g7OqX1LhYMhh7NFipyMeyA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.9.0.tgz",
+      "integrity": "sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==",
+      "license": "GPL-3.0-or-later",
       "peerDependencies": {
-        "@subsquid/logger": "^1.3.3"
+        "@subsquid/logger": "^1.6.0"
       },
       "peerDependenciesMeta": {
         "@subsquid/logger": {
@@ -3736,7 +3752,8 @@
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
-      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -4260,6 +4277,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
       "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
       "dependencies": {
         "es5-ext": "^0.10.64",
         "type": "^2.7.2"
@@ -4525,6 +4543,7 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
       "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -4539,6 +4558,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -4549,6 +4569,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
       "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.2",
         "ext": "^1.7.0"
@@ -5058,6 +5079,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
       "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -5140,6 +5162,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -5191,6 +5214,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -6188,7 +6212,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -6582,7 +6607,8 @@
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -7167,6 +7193,7 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
       "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tdigest": "^0.1.1"
       },
@@ -7880,6 +7907,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
       "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
       }
@@ -7966,7 +7994,8 @@
     "node_modules/type": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8009,6 +8038,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -8292,6 +8322,7 @@
       "version": "1.0.35",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
       "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
@@ -8550,6 +8581,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.32"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-sns": "^3.622.0",
     "@dcl/schemas": "^13.4.0",
     "@subsquid/evm-abi": "^0.3.0",
-    "@subsquid/evm-processor": "^1.19.1",
+    "@subsquid/evm-processor": "^1.30.1",
     "@subsquid/typeorm-migration": "^1.3.0",
     "@subsquid/typeorm-store": "^1.5.1",
     "dotenv": "^16.4.5",

--- a/src/common/processor.ts
+++ b/src/common/processor.ts
@@ -30,7 +30,7 @@ export function createOffchainMarketplaceProcessor({
   return new EvmBatchProcessor()
     .setBlockRange({ from: fromBlock })
     .setPrometheusPort(prometheusPort)
-    .setGateway(gateway)
+    .setGateway({ url: gateway, apiKey: process.env.SQUID_API_KEY })
     .setRpcEndpoint({
       url: rpcEndpoint,
       rateLimit: 10


### PR DESCRIPTION
## Changes

- Bump \`@subsquid/evm-processor\` from \`^1.19.1\` to \`^1.30.1\`. As of \`1.30.0\` (released 2026-05-05) the Subsquid gateway requires an API key (anonymous access returns 403 \`CREDENTIALS_INVALID\`).
- Pass the API key through \`setGateway({ url, apiKey })\` in \`src/common/processor.ts\`, reading it from \`process.env.SQUID_API_KEY\`. Same env var name we are adopting across the 3 squids for consistency.

The matching SSM parameter is being added in the \`definitions\` repo so the secret reaches the container at runtime.

## Test plan

- [ ] CI green
- [ ] Local processor run picks up the key and indexes without 403s