### PR TITLE
fix: install awscli with --break-system-packages on alpine pep 668

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,10 @@ RUN echo -e "loglevel=silent\\nupdate-notifier=false" > /squid/.npmrc
 RUN npm i -g @subsquid/cli@latest && mv $(which sqd) /usr/local/bin/sqd
 
 # Install jq and AWS CLI v1
+# --break-system-packages is required since the alpine base image ships a PEP 668
+# "externally-managed" Python, which otherwise rejects the pip install.
 RUN apk update && apk add --no-cache tini postgresql-client curl jq python3 py3-pip \
-    && pip3 install awscli \
+    && pip3 install --break-system-packages awscli \
     && rm -rf /var/cache/apk/*
 
 ENV ETH_PROMETHEUS_PORT 3000


### PR DESCRIPTION
## Context

The Docker image build (buildah → quay) fails on the `pip3 install awscli` step. The alpine base image now ships a PEP 668 "externally-managed" Python, so the install aborts with:

```
error: externally-managed-environment
Error: building at STEP "RUN apk update && apk add ... python3 py3-pip && pip3 install awscli ...": exit status 1
```

CI run: https://github.com/decentraland/trades-squid-core/actions/runs/27293614088

(Same failure as decentraland/marketplace-squid-core#83.)

## Changes

- Add `--break-system-packages` to the `pip3 install awscli` step in the `Dockerfile`. Keeps the same AWS CLI v1 (used by `indexer.sh` for `aws ecs describe-tasks`); only unblocks the install under PEP 668.

## Test plan

- [ ] CI image build (buildah) completes past the `pip3 install awscli` step

> Note: the image build (`quay-build-push`) only runs on push to `main`, so it validates on merge. Couldn't run the Docker build locally (daemon unavailable). Cleaner long-term alternative: drop pip and use Alpine's `aws-cli` package (`apk add aws-cli`).