### PR TITLE
fix: derive the trade row id from the log coordinates

### DIFF
--- a/db/migrations/1784999578365-Data.js
+++ b/db/migrations/1784999578365-Data.js
@@ -1,8 +1,8 @@
-module.exports = class Data1728499832070 {
-    name = 'Data1728499832070'
+module.exports = class Data1784999578365 {
+    name = 'Data1784999578365'
 
     async up(db) {
-        await db.query(`CREATE TABLE "trade" ("id" character varying NOT NULL, "signature" text NOT NULL, "network" character varying(8) NOT NULL, "action" character varying(9) NOT NULL, "timestamp" numeric, "caller" text NOT NULL, "tx_hash" text NOT NULL, "sent_beneficiary" text, "received_beneficiary" text, CONSTRAINT "PK_d4097908741dc408f8274ebdc53" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE TABLE "trade" ("id" character varying NOT NULL, "signature" text NOT NULL, "network" character varying(8) NOT NULL, "action" character varying(9) NOT NULL, "timestamp" numeric, "caller" text NOT NULL, "tx_hash" text NOT NULL, "log_index" integer NOT NULL, "sent_beneficiary" text, "received_beneficiary" text, "sent_beneficiaries" text array NOT NULL, "received_beneficiaries" text array NOT NULL, CONSTRAINT "PK_d4097908741dc408f8274ebdc53" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_1897941180275e08180df10725" ON "trade" ("signature") `)
         await db.query(`CREATE TABLE "signature_index" ("id" character varying NOT NULL, "address" text NOT NULL, "network" character varying(8) NOT NULL, "index" integer NOT NULL, CONSTRAINT "PK_ffa4422e3338f8a5632922e6d4e" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_836f411c550ddeb130a661e9fe" ON "signature_index" ("address") `)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "@subsquid/typeorm-migration": "^1.3.0",
         "@subsquid/typeorm-store": "^1.5.1",
         "dotenv": "^16.4.5",
-        "typeorm": "^0.3.20",
-        "uuid": "^11.0.5"
+        "typeorm": "^0.3.20"
       },
       "devDependencies": {
         "@dcl/eslint-config": "^2.2.1",
@@ -8272,18 +8271,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-or-promise": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "@subsquid/typeorm-migration": "^1.3.0",
     "@subsquid/typeorm-store": "^1.5.1",
     "dotenv": "^16.4.5",
-    "typeorm": "^0.3.20",
-    "uuid": "^11.0.5"
+    "typeorm": "^0.3.20"
   },
   "devDependencies": {
     "@dcl/eslint-config": "^2.2.1",

--- a/schema.graphql
+++ b/schema.graphql
@@ -3,6 +3,12 @@ enum Network {
   POLYGON
 }
 
+"""
+One row per Traded / SignatureCancelled LOG (not per transaction, and not per signature).
+
+`id` is derived from the log's on-chain coordinates (`txHash-logIndex`) rather than generated, which is
+what makes a row identifiable across reindexes. See the handler for why that matters.
+"""
 type Trade @entity {
   id: ID!
   signature: String! @index
@@ -11,8 +17,23 @@ type Trade @entity {
   timestamp: BigInt
   caller: String!
   txHash: String!
+  """
+  Index of the log within its transaction. Combined with `txHash` it uniquely and STABLY identifies this
+  event, which `signature` alone does not: one transaction can execute the same multi-use trade more than
+  once (a cart buying 2 units of one listing), emitting several Traded logs that are identical in every
+  other column. Consumers that must process each fill exactly once need this to tell them apart.
+  """
+  logIndex: Int!
   sentBeneficiary: String
   receivedBeneficiary: String
+  """
+  Beneficiaries of ALL `sent` / `received` legs, in trade order. The singular `sentBeneficiary` /
+  `receivedBeneficiary` above only ever carry leg `[0]`, so a trade routing its price to one address and
+  a fee/royalty to another is invisible to anyone filtering on them — the money moves and the consumer
+  never sees it. These arrays are additive; the singular fields are kept for existing consumers.
+  """
+  sentBeneficiaries: [String!]!
+  receivedBeneficiaries: [String!]!
 }
 
 enum TradeAction {

--- a/src/common/handler.ts
+++ b/src/common/handler.ts
@@ -1,7 +1,6 @@
 import { DataHandlerContext, Log } from '@subsquid/evm-processor'
 import { Store } from '@subsquid/typeorm-store'
 import { In } from 'typeorm'
-import { v4 as uuidv4 } from 'uuid';
 import { ContractStatus, Network, SignatureIndex, TradeAction, Trade } from '../model'
 import { OffchainMarketplaceAbi } from './types'
 import { sendEvents } from './utils/events'
@@ -63,6 +62,26 @@ async function getIndexesToUpsert(store: Store, network: Network, modifiedIndexe
   })
 }
 
+/**
+ * Stable, content-addressed row id: the log's own on-chain coordinates.
+ *
+ * This REPLACED `uuidv4()`, and the difference is not cosmetic:
+ *
+ *  - A generated id is not derived from the event, so re-processing the same log — a reorg rollback, or
+ *    the routine full reindex a schema change forces — yields a DIFFERENT id. Any downstream consumer
+ *    that treats a row as "one unit of work already done" is then unable to recognise it. For the
+ *    treasury consumer that credits sellers, re-crediting the entire indexed history is a direct loss.
+ *  - It also makes `store.upsert` genuinely idempotent: re-processing a log now writes the SAME primary
+ *    key instead of inserting a second row for one on-chain event.
+ *
+ * `(txHash, logIndex)` is unique and immutable for a log on a canonical chain, which is exactly the
+ * property an id needs. Note that `signature` is NOT unique per row: one transaction can execute the
+ * same multi-use trade several times, emitting several Traded logs that differ only by log index.
+ */
+function tradeRowId(txHash: string, logIndex: number): string {
+  return `${txHash}-${logIndex}`
+}
+
 export function getDataHandler(marketplaceAbi: OffchainMarketplaceAbi, marketplaceContractAddress: string, network: Network) {
   return async function (ctx: DataHandlerContext<Store, unknown>) {
     const tradesToInsert: Trade[] = []
@@ -81,15 +100,20 @@ export function getDataHandler(marketplaceAbi: OffchainMarketplaceAbi, marketpla
             const { _signature, _trade, _caller } = marketplaceAbi.events.Traded.decode(log)
             tradesToInsert.push(
               new Trade({
-                id: uuidv4(),
+                id: tradeRowId(transactionHash, log.logIndex),
                 network,
                 action: TradeAction.executed,
                 signature: _signature,
                 timestamp,
                 caller: _caller,
                 txHash: transactionHash,
+                logIndex: log.logIndex,
+                // Leg [0] kept for existing consumers; the arrays carry every leg so a trade that splits
+                // its proceeds across beneficiaries is not invisible to whoever filters on one address.
                 sentBeneficiary: _trade.sent[0].beneficiary,
-                receivedBeneficiary: _trade.received[0].beneficiary
+                receivedBeneficiary: _trade.received[0].beneficiary,
+                sentBeneficiaries: _trade.sent.map(asset => asset.beneficiary),
+                receivedBeneficiaries: _trade.received.map(asset => asset.beneficiary)
               })
             )
             break
@@ -114,15 +138,18 @@ export function getDataHandler(marketplaceAbi: OffchainMarketplaceAbi, marketpla
             const { _signature, _caller } = marketplaceAbi.events.SignatureCancelled.decode(log)
             tradesToInsert.push(
               new Trade({
-                id: uuidv4(),
+                id: tradeRowId(transactionHash, log.logIndex),
                 network,
                 action: TradeAction.cancelled,
                 signature: _signature,
                 timestamp,
                 txHash: transactionHash,
+                logIndex: log.logIndex,
                 sentBeneficiary: null,
                 caller: _caller,
-                receivedBeneficiary: null
+                receivedBeneficiary: null,
+                sentBeneficiaries: [],
+                receivedBeneficiaries: []
               })
             )
             break

--- a/src/model/generated/trade.model.ts
+++ b/src/model/generated/trade.model.ts
@@ -1,7 +1,13 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, BigIntColumn as BigIntColumn_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, BigIntColumn as BigIntColumn_, IntColumn as IntColumn_} from "@subsquid/typeorm-store"
 import {Network} from "./_network"
 import {TradeAction} from "./_tradeAction"
 
+/**
+ * One row per Traded / SignatureCancelled LOG (not per transaction, and not per signature).
+ * 
+ * `id` is derived from the log's on-chain coordinates (`txHash-logIndex`) rather than generated, which is
+ * what makes a row identifiable across reindexes. See the handler for why that matters.
+ */
 @Entity_()
 export class Trade {
     constructor(props?: Partial<Trade>) {
@@ -30,9 +36,30 @@ export class Trade {
     @StringColumn_({nullable: false})
     txHash!: string
 
+    /**
+     * Index of the log within its transaction. Combined with `txHash` it uniquely and STABLY identifies this
+     * event, which `signature` alone does not: one transaction can execute the same multi-use trade more than
+     * once (a cart buying 2 units of one listing), emitting several Traded logs that are identical in every
+     * other column. Consumers that must process each fill exactly once need this to tell them apart.
+     */
+    @IntColumn_({nullable: false})
+    logIndex!: number
+
     @StringColumn_({nullable: true})
     sentBeneficiary!: string | undefined | null
 
     @StringColumn_({nullable: true})
     receivedBeneficiary!: string | undefined | null
+
+    /**
+     * Beneficiaries of ALL `sent` / `received` legs, in trade order. The singular `sentBeneficiary` /
+     * `receivedBeneficiary` above only ever carry leg `[0]`, so a trade routing its price to one address and
+     * a fee/royalty to another is invisible to anyone filtering on them — the money moves and the consumer
+     * never sees it. These arrays are additive; the singular fields are kept for existing consumers.
+     */
+    @StringColumn_({array: true, nullable: false})
+    sentBeneficiaries!: (string)[]
+
+    @StringColumn_({array: true, nullable: false})
+    receivedBeneficiaries!: (string)[]
 }


### PR DESCRIPTION
## Why

`Trade.id` was `uuidv4()` — not derived from the event it represents. Two consequences, both of which bite any consumer that treats a row as a unit of work:

1. **Rows are unidentifiable across re-processing.** A reorg rollback, or the full reindex a schema change forces, produces a *different* id for the very same log. A consumer that recorded "I already handled row X" can no longer recognise it. For the treasury consumer being built in credits-server — which credits a seller for each observed fill — that means re-crediting the entire indexed history on any reindex.
2. **`store.upsert` could not be idempotent.** Re-processing a log inserted a *second* row for one on-chain event, because the primary key was fresh each time.

Separately, `(txHash, signature)` is **not** a unique key for a row, which consumers naturally assume it is: one transaction can execute the same multi-use trade several times — a cart buying 2 units of one listing calls `accept([trade, trade])` — emitting several `Traded` logs identical in every stored column. There was no field to tell them apart.

## Changes

**1. `id` is now `${txHash}-${logIndex}`.** Unique and immutable for a log on a canonical chain, so it survives reindexing and makes upserts genuinely idempotent. `uuid` is dropped as a dependency.

**2. New `logIndex` column.** Exposed explicitly, not only baked into the id, so consumers can order and de-duplicate on it: `(timestamp, txHash, logIndex)` is a deterministic *total* order, whereas `(timestamp, txHash, signature)` cannot separate two fills of one trade in one tx — keyset pagination over it silently skips rows.

**3. New `sentBeneficiaries` / `receivedBeneficiaries` arrays.** The singular `sentBeneficiary` / `receivedBeneficiary` only ever carried leg `[0]`, so a trade routing its price to one address and a fee/royalty to another was invisible to anyone filtering on those columns — the money moves and the consumer never sees the fill. The arrays carry every leg, in trade order.

Both new columns are **additive**: the singular fields keep their current meaning and values, so existing consumers (marketplace-server's trades MV joins on `signature`) are unaffected.

## Migration

Regenerated with `squid-typeorm-migration generate`, following this repo's convention of a single squashed `Data` migration. Verified by applying it to a clean database and inspecting the resulting schema; entity/PK/index names are unchanged, so the diff is limited to the three new columns.

**This requires a reindex** — `id` values change format, so existing rows would not be updated in place.

## Test plan

- [x] `squid-typeorm-codegen` regenerates the model cleanly
- [x] `npm run build` (tsc) passes
- [x] `squid-typeorm-migration generate` + `apply` against a clean DB; schema verified column by column
- [x] `npm run check:code` (eslint) and `npm run check:prettier` pass
- [ ] Reindex on Amoy and confirm `id` = `txHash-logIndex`, `log_index` populated, and a multi-fill transaction yields one row per fill