### PR TITLE
feat: index the trade keyset and grant the credits read-only role

### DIFF
--- a/db/migrations/1785084434732-Data.js
+++ b/db/migrations/1785084434732-Data.js
@@ -1,9 +1,10 @@
-module.exports = class Data1784999578365 {
-    name = 'Data1784999578365'
+module.exports = class Data1785084434732 {
+    name = 'Data1785084434732'
 
     async up(db) {
         await db.query(`CREATE TABLE "trade" ("id" character varying NOT NULL, "signature" text NOT NULL, "network" character varying(8) NOT NULL, "action" character varying(9) NOT NULL, "timestamp" numeric, "caller" text NOT NULL, "tx_hash" text NOT NULL, "log_index" integer NOT NULL, "sent_beneficiary" text, "received_beneficiary" text, "sent_beneficiaries" text array NOT NULL, "received_beneficiaries" text array NOT NULL, CONSTRAINT "PK_d4097908741dc408f8274ebdc53" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_1897941180275e08180df10725" ON "trade" ("signature") `)
+        await db.query(`CREATE INDEX "IDX_b7b7bf5b270d79c9793b97f353" ON "trade" ("timestamp", "tx_hash", "log_index") `)
         await db.query(`CREATE TABLE "signature_index" ("id" character varying NOT NULL, "address" text NOT NULL, "network" character varying(8) NOT NULL, "index" integer NOT NULL, CONSTRAINT "PK_ffa4422e3338f8a5632922e6d4e" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_836f411c550ddeb130a661e9fe" ON "signature_index" ("address") `)
         await db.query(`CREATE TABLE "contract_status" ("id" character varying NOT NULL, "address" text NOT NULL, "network" character varying(8) NOT NULL, "paused" boolean NOT NULL, CONSTRAINT "PK_14a66107c6d68e6c40c80de1f86" PRIMARY KEY ("id"))`)
@@ -13,6 +14,7 @@ module.exports = class Data1784999578365 {
     async down(db) {
         await db.query(`DROP TABLE "trade"`)
         await db.query(`DROP INDEX "public"."IDX_1897941180275e08180df10725"`)
+        await db.query(`DROP INDEX "public"."IDX_b7b7bf5b270d79c9793b97f353"`)
         await db.query(`DROP TABLE "signature_index"`)
         await db.query(`DROP INDEX "public"."IDX_836f411c550ddeb130a661e9fe"`)
         await db.query(`DROP TABLE "contract_status"`)

--- a/indexer.sh
+++ b/indexer.sh
@@ -8,6 +8,9 @@ SQUID_READER_USER="trades_squid_api_reader"
 MARKETPLACE_SERVER_API_READER_USER="dapps_marketplace_user"
 MARKETPLACE_TRADES_MV_ROLE="mv_trades_owner"
 ATLAS_SERVER_READONLY_USER="atlas_server_readonly_user"
+# credits-server's read-only role for the "proceeds to treasury" flow. Granted CONDITIONALLY below (see
+# there for why), because it is created per environment by ops rather than by this script.
+CREDITS_TRADES_RO_USER="credits_trades_ro"
 SQUIDS_PUBLIC_TABLE="squids"
 MARKETPLACE_SCHEMA="marketplace"
 
@@ -75,6 +78,30 @@ else
 
     ALTER DEFAULT PRIVILEGES FOR ROLE $NEW_DB_USER IN SCHEMA $NEW_SCHEMA_NAME
       GRANT SELECT ON TABLES TO $ATLAS_SERVER_READONLY_USER;
+
+    -- credits-server's read-only role for the "proceeds to treasury" flow.
+    --
+    -- It has to be granted HERE, not once by hand: every deploy indexes into a brand-new schema owned by a
+    -- brand-new user, and \`upgrade.sh\` then renames that schema over \`squid_trades\`. Privileges follow the
+    -- object, not the name, so a manual grant on today's table is gone the moment the next reindex is
+    -- promoted — the consumer would start failing every pass with a permission error, and only after a
+    -- promotion, which is the worst time to discover it.
+    --
+    -- CONDITIONAL because the role is provisioned per environment by ops and this script runs under
+    -- ON_ERROR_STOP=1: an unconditional GRANT would abort the entire squid deploy in any environment where
+    -- the role does not exist yet. Missing role => the proceeds flow is simply not provisioned there.
+    DO \$\$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '$CREDITS_TRADES_RO_USER') THEN
+        EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', '$NEW_SCHEMA_NAME', '$CREDITS_TRADES_RO_USER');
+        EXECUTE format(
+          'GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', '$NEW_SCHEMA_NAME', '$CREDITS_TRADES_RO_USER');
+        EXECUTE format(
+          'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT SELECT ON TABLES TO %I',
+          '$NEW_DB_USER', '$NEW_SCHEMA_NAME', '$CREDITS_TRADES_RO_USER');
+      END IF;
+    END
+    \$\$;
 
     -- Grant insert/update to squid public table
     GRANT SELECT, INSERT, UPDATE ON TABLE $SQUIDS_PUBLIC_TABLE TO $NEW_DB_USER;

--- a/schema.graphql
+++ b/schema.graphql
@@ -8,8 +8,16 @@ One row per Traded / SignatureCancelled LOG (not per transaction, and not per si
 
 `id` is derived from the log's on-chain coordinates (`txHash-logIndex`) rather than generated, which is
 what makes a row identifiable across reindexes. See the handler for why that matters.
+
+The composite index matches the `(timestamp, txHash, logIndex)` keyset that consumers paginate this table
+by — the same tuple as their ORDER BY, so a scan resuming from a watermark is an index range read instead
+of a sequential scan plus a sort of the whole table on every pass.
+
+That tuple, not `timestamp` alone: `timestamp` is block time and repeats across every trade in a block (and
+across blocks mined in the same second), so a single-column index still leaves the tie-break columns to be
+sorted. Ordering all three the same way the consumers do makes the resume position directly seekable.
 """
-type Trade @entity {
+type Trade @entity @index(fields: ["timestamp", "txHash", "logIndex"]) {
   id: ID!
   signature: String! @index
   network: Network!

--- a/src/model/generated/trade.model.ts
+++ b/src/model/generated/trade.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, BigIntColumn as BigIntColumn_, IntColumn as IntColumn_} from "@subsquid/typeorm-store"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, Index as Index_, StringColumn as StringColumn_, BigIntColumn as BigIntColumn_, IntColumn as IntColumn_} from "@subsquid/typeorm-store"
 import {Network} from "./_network"
 import {TradeAction} from "./_tradeAction"
 
@@ -7,7 +7,16 @@ import {TradeAction} from "./_tradeAction"
  * 
  * `id` is derived from the log's on-chain coordinates (`txHash-logIndex`) rather than generated, which is
  * what makes a row identifiable across reindexes. See the handler for why that matters.
+ * 
+ * The composite index matches the `(timestamp, txHash, logIndex)` keyset that consumers paginate this table
+ * by — the same tuple as their ORDER BY, so a scan resuming from a watermark is an index range read instead
+ * of a sequential scan plus a sort of the whole table on every pass.
+ * 
+ * That tuple, not `timestamp` alone: `timestamp` is block time and repeats across every trade in a block (and
+ * across blocks mined in the same second), so a single-column index still leaves the tie-break columns to be
+ * sorted. Ordering all three the same way the consumers do makes the resume position directly seekable.
  */
+@Index_(["timestamp", "txHash", "logIndex"], {unique: false})
 @Entity_()
 export class Trade {
     constructor(props?: Partial<Trade>) {


### PR DESCRIPTION
Two things the proceeds flow needs from the squid deploy. Both only take effect on the next reindex, so they should go out together with one indexing run.

## 1. Index the keyset consumers paginate by

credits-server scans this table with a watermark: `WHERE (timestamp, tx_hash, log_index) > (…) ORDER BY timestamp, tx_hash, log_index LIMIT n`, every 30s for the life of the process. The table had only two indexes — the `id` primary key and one on `signature` — so that scan was a full sequential scan plus a sort of the entire table, discarded after taking 200 rows.

Measured on a 50k-row local table, same query:

**Before**
```
Limit
  ->  Sort
        Sort Key: "timestamp", tx_hash, log_index
        ->  Seq Scan on trade
              Filter: (action = 'executed' AND network = 'POLYGON' AND ROW(...) > ROW(...))
```

**After**
```
Limit
  ->  Index Scan using "IDX_b7b7bf5b270d79c9793b97f353" on trade
        Index Cond: (ROW("timestamp", tx_hash, log_index) > ROW(...))
        Filter: (action = 'executed' AND network = 'POLYGON' AND EXISTS(SubPlan 1))
```

The row-value comparison becomes the index condition and the sort disappears entirely — the resume position is seeked directly.

It is the composite tuple rather than `timestamp` alone on purpose: `timestamp` is block time, so it repeats across every trade in a block and across blocks mined in the same second. A single-column index would still leave the tie-break columns to sort.

`schema.graphql` gets `@index(fields: ["timestamp", "txHash", "logIndex"])`; the model and the migration are regenerated with the tooling. The regenerated migration is byte-identical to the previous one apart from the new `CREATE INDEX` line (and the class name/timestamp), following the same regenerate-in-place convention as #38.

## 2. Grant the credits-server read-only role in `indexer.sh`

credits-server reads `squid_trades.trade` as a dedicated least-privilege role, `credits_trades_ro`.

That grant has to live in this script rather than being issued once by hand. Every deploy indexes into a brand-new schema owned by a brand-new user, and `upgrade.sh` then renames that schema over `squid_trades`. Privileges follow the object, not the name — so a manual grant on today's table is gone the moment the next reindex is promoted. The consumer would start failing every pass with a permission error, discovered only *after* a promotion, which is the worst possible time.

This is already how every other reader is wired: `dapps_marketplace_user`, `trades_squid_api_reader`, `mv_trades_owner` and `atlas_server_readonly_user` all get their USAGE and default privileges here, per deploy. This adds one more to that list.

**The grant is conditional on the role existing.** The role is provisioned per environment by ops, and this script runs under `ON_ERROR_STOP=1` — an unconditional `GRANT` would abort the entire squid deploy in any environment where the role has not been created yet. A missing role simply means the proceeds flow is not provisioned there.

## Verification

`squid-typeorm-codegen` and `tsc` clean. I applied the regenerated migration to a scratch Postgres, loaded 50k rows and ran the EXPLAIN comparison above.

Not verified by me: the `indexer.sh` change, which needs a real deploy to exercise. The conditional block is a plain `DO … IF EXISTS (SELECT 1 FROM pg_roles …)`, so the no-role path is a no-op, but it is worth watching the first indexer run's output.
