### PR TITLE
fix: index a Traded event that has no received leg

### DIFF
--- a/src/common/handler.ts
+++ b/src/common/handler.ts
@@ -110,8 +110,14 @@ export function getDataHandler(marketplaceAbi: OffchainMarketplaceAbi, marketpla
                 logIndex: log.logIndex,
                 // Leg [0] kept for existing consumers; the arrays carry every leg so a trade that splits
                 // its proceeds across beneficiaries is not invisible to whoever filters on one address.
-                sentBeneficiary: _trade.sent[0].beneficiary,
-                receivedBeneficiary: _trade.received[0].beneficiary,
+                //
+                // Both legs are OPTIONAL. A trade with nothing in `received` is a giveaway — the signer
+                // hands over an asset and takes no payment — and the contract accepts it, so the event is
+                // valid on-chain data, not a malformed log. Indexing `[0]` unguarded read `undefined` and
+                // threw inside the batch transaction, which the processor treats as fatal: it crash-looped
+                // on that block and stopped indexing every trade behind it (prod, 2026-08-07).
+                sentBeneficiary: _trade.sent[0]?.beneficiary ?? null,
+                receivedBeneficiary: _trade.received[0]?.beneficiary ?? null,
                 sentBeneficiaries: _trade.sent.map(asset => asset.beneficiary),
                 receivedBeneficiaries: _trade.received.map(asset => asset.beneficiary)
               })


### PR DESCRIPTION
## The outage

The polygon processor is crash-looping in prod and has indexed no trade since block **91576310**:

```
FATAL sqd:processor TypeError: Cannot read properties of undefined (reading 'beneficiary')
  at /squid/lib/common/handler.js:94
```

It restarts, resumes from the same block, hits the same log, dies. Nothing behind it gets indexed.

## What is actually in that block

```ts
sentBeneficiary: _trade.sent[0].beneficiary,
receivedBeneficiary: _trade.received[0].beneficiary,
```

`_trade.received` is `[]`, so `received[0]` is `undefined`.

Scanned every `Traded` log from 91576311 to head on both marketplace contracts. **Two** are shaped this way, both `sent: 1, received: 0`:

| block | tx | signer | sent |
|---|---|---|---|
| 91576312 | `0x196fd4ad…c9289` | `0xC3E3…fc98` | assetType 3 → `0xE8d7…3295` |
| 91578006 | `0x91a3180b…7c07f` | `0xC3E3…fc98` | assetType 3 → `0xE8d7…3295` |

A trade whose signer hands over an asset and takes **no payment** — a giveaway. Same signer, same beneficiary, both submitted through the DCL meta-tx relayer (`0xebf9eb2a…`), so this is a product flow, not a malformed log and not an attack. The contract accepts it, which makes it valid on-chain data the indexer has to be able to read.

Nothing here is a regression from a recent PR: those two lines predate the trade-keyset change (#40), which only added the plural `sentBeneficiaries` / `receivedBeneficiaries` arrays alongside them. The bug has always been latent; this is the first trade that took the branch.

## The fix

```ts
sentBeneficiary: _trade.sent[0]?.beneficiary ?? null,
receivedBeneficiary: _trade.received[0]?.beneficiary ?? null,
```

Both columns are already nullable (`String` in the schema — the `SignatureCancelled` branch writes `null` into them today), so this needs no migration. The plural arrays need no guard: `[].map()` is `[]`, and the `SignatureCancelled` branch already writes `[]`.

The row is **kept**, not skipped. The `Traded` event happened on-chain and consumers filtering by signature or caller should still see it; dropping it would trade a crash for a silent hole.

## After merge

The processor resumes from 91576311 on its own — no reindex, no manual DB work. Worth confirming both rows land with a null `receivedBeneficiary` and that `mv_trades` refreshes past the gap.

## Not covered

No test. This repo has no test harness at all (no `test` script, no spec files), and standing one up mid-outage is the wrong order of operations. Worth a follow-up: the handler decodes five event shapes off raw logs and a single unguarded field in any of them halts prod the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyGCPEq4PxTSefUeBw6yX1
